### PR TITLE
Improve native notifications support

### DIFF
--- a/src/Models/Messenger.vala
+++ b/src/Models/Messenger.vala
@@ -20,7 +20,44 @@
 */
 
 public class Models.Messenger : Object {
-    public string id;
-    public string name;
-    public string url;
+    private string _id;
+    private string _name;
+    private string _url;
+    private uint _unread_notifications = 0;
+
+    public string id {
+        get {
+            return _id;
+        }
+        set {
+            _id = value;
+        }
+    }
+
+    public string name {
+        get {
+            return _name;
+        }
+        set {
+            _name = value;
+        }
+    }
+
+    public string url {
+        get {
+            return _url;
+        }
+        set {
+            _url = value;
+        }
+    }
+
+    public uint unread_notifications {
+        get {
+            return _unread_notifications;
+        }
+        set {
+            _unread_notifications = value;
+        }
+    }
 }

--- a/src/Models/Messenger.vala
+++ b/src/Models/Messenger.vala
@@ -1,0 +1,22 @@
+/*
+* Copyright (c) 2020 Manexim (https://github.com/manexim)
+*
+* This program is free software; you can redistribute it and/or
+* modify it under the terms of the GNU General Public
+* License as published by the Free Software Foundation; either
+* version 2 of the License, or (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+* General Public License for more details.
+*
+* You should have received a copy of the GNU General Public
+* License along with this program; if not, write to the
+* Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+* Boston, MA 02110-1301 USA
+*
+* Authored by: Marius Meisenzahl <mariusmeisenzahl@gmail.com>
+*/
+
+public class Models.Messenger : Object {}

--- a/src/Models/Messenger.vala
+++ b/src/Models/Messenger.vala
@@ -19,4 +19,8 @@
 * Authored by: Marius Meisenzahl <mariusmeisenzahl@gmail.com>
 */
 
-public class Models.Messenger : Object {}
+public class Models.Messenger : Object {
+    public string id;
+    public string name;
+    public string url;
+}

--- a/src/Services/Messengers.vala
+++ b/src/Services/Messengers.vala
@@ -1,0 +1,62 @@
+/*
+* Copyright (c) 2020 Manexim (https://github.com/manexim)
+*
+* This program is free software; you can redistribute it and/or
+* modify it under the terms of the GNU General Public
+* License as published by the Free Software Foundation; either
+* version 2 of the License, or (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+* General Public License for more details.
+*
+* You should have received a copy of the GNU General Public
+* License along with this program; if not, write to the
+* Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+* Boston, MA 02110-1301 USA
+*
+* Authored by: Marius Meisenzahl <mariusmeisenzahl@gmail.com>
+*/
+
+public class Services.Messengers {
+    private static Messengers instance;
+    private Models.Messenger[] _data;
+
+    public static Messengers get_default () {
+        if (instance == null) {
+            instance = new Messengers ();
+        }
+
+        return instance;
+    }
+
+    public Models.Messenger[] data {
+        get {
+            return _data;
+        }
+    }
+
+    private Messengers () {
+        _data = new Models.Messenger[4];
+        _data[0] = new Models.Messenger ();
+        _data[0].id = "com.messenger";
+        _data[0].name = "Messenger";
+        _data[0].url = "https://www.messenger.com/";
+
+        _data[1] = new Models.Messenger ();
+        _data[1].id = "com.slack";
+        _data[1].name = "Slack";
+        _data[1].url = "https://slack.com/signin/";
+
+        _data[2] = new Models.Messenger ();
+        _data[2].id = "org.telegram.web";
+        _data[2].name = "Telegram";
+        _data[2].url = "https://web.telegram.org/";
+
+        _data[3] = new Models.Messenger ();
+        _data[3].id = "com.whatsapp.web";
+        _data[3].name = "WhatsApp";
+        _data[3].url = "https://web.whatsapp.com/";
+    }
+}

--- a/src/Views/MainView.vala
+++ b/src/Views/MainView.vala
@@ -34,18 +34,31 @@ public class Views.MainView : Gtk.Paned {
         var messengers = Services.Messengers.get_default ().data;
         for (var i = 0; i < messengers.length; i++) {
             var messenger = messengers[i];
-            info (messenger.id);
 
-            stack.add_named (new Widgets.MessengerView (messenger), "%d".printf (i));
+            var view = new Widgets.MessengerView (messenger);
+            stack.add_named (view, "%d".printf (i));
 
             var menu_item = new Gtk.MenuItem ();
 
             var image = new Gtk.Image.from_gicon (Utilities.load_shared_icon (messenger.id), Gtk.IconSize.DND);
             var label = new Gtk.Label (messenger.name);
+            var unread_notifications = new Gtk.Label (
+                (messenger.unread_notifications > 0) ? "%u".printf (messenger.unread_notifications) : ""
+            );
+
+            messenger.notify.connect (() => {
+                debug ("[%s] unread_notifications: %u", messenger.id, messenger.unread_notifications);
+
+                if (stack.get_visible_child () != view) {
+                    unread_notifications.label =
+                        (messenger.unread_notifications > 0) ? "%u".printf (messenger.unread_notifications) : "";
+                }
+            });
 
             var box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 0);
             box.pack_start (image, false, false, 0);
             box.pack_start (label, false, false, 0);
+            box.pack_end (unread_notifications, false, false, 0);
 
             menu_item.add (box);
 

--- a/src/Views/MainView.vala
+++ b/src/Views/MainView.vala
@@ -55,6 +55,27 @@ public class Views.MainView : Gtk.Paned {
                 } else if (messenger.unread_notifications == 0) {
                     unread_notifications.label = "";
                 }
+
+                uint unread_notifications_sum = 0;
+                foreach (var m in messengers) {
+                    unread_notifications_sum += m.unread_notifications;
+                }
+
+                Granite.Services.Application.set_badge.begin (unread_notifications_sum, (obj, res) => {
+                    try {
+                        Granite.Services.Application.set_badge.end (res);
+                    } catch (GLib.Error e) {
+                        critical (e.message);
+                    }
+                });
+
+                Granite.Services.Application.set_badge_visible.begin (unread_notifications_sum != 0U, (obj, res) => {
+                    try {
+                        Granite.Services.Application.set_badge_visible.end (res);
+                    } catch (GLib.Error e) {
+                        critical (e.message);
+                    }
+                });
             });
 
             var box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 0);

--- a/src/Views/MainView.vala
+++ b/src/Views/MainView.vala
@@ -26,21 +26,22 @@ public class Views.MainView : Gtk.Paned {
         var grid = new Gtk.Grid ();
         var stack = new Gtk.Stack ();
 
-        stack.add_named (new Widgets.WebView ("https://www.messenger.com/", "com.messenger"), "0");
-        stack.add_named (new Widgets.WebView ("https://slack.com/signin/", "com.slack"), "1");
-        stack.add_named (new Widgets.WebView ("https://web.telegram.org/", "org.telegram.web"), "2");
-        stack.add_named (new Widgets.WebView ("https://web.whatsapp.com/", "com.whatsapp.web"), "3");
-
         grid.orientation = Gtk.Orientation.VERTICAL;
         var list_box = new Gtk.ListBox ();
         list_box.selection_mode = Gtk.SelectionMode.SINGLE;
         list_box.activate_on_single_click = true;
 
-        {
+        var messengers = Services.Messengers.get_default ().data;
+        for (var i = 0; i < messengers.length; i++) {
+            var messenger = messengers[i];
+            info (messenger.id);
+
+            stack.add_named (new Widgets.MessengerView (messenger), "%d".printf (i));
+
             var menu_item = new Gtk.MenuItem ();
 
-            var image = new Gtk.Image.from_gicon (Utilities.load_shared_icon ("com.messenger"), Gtk.IconSize.DND);
-            var label = new Gtk.Label ("Messenger");
+            var image = new Gtk.Image.from_gicon (Utilities.load_shared_icon (messenger.id), Gtk.IconSize.DND);
+            var label = new Gtk.Label (messenger.name);
 
             var box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 0);
             box.pack_start (image, false, false, 0);
@@ -48,52 +49,7 @@ public class Views.MainView : Gtk.Paned {
 
             menu_item.add (box);
 
-            list_box.insert (menu_item, 0);
-        }
-
-        {
-            var menu_item = new Gtk.MenuItem ();
-
-            var image = new Gtk.Image.from_gicon (Utilities.load_shared_icon ("com.slack"), Gtk.IconSize.DND);
-            var label = new Gtk.Label ("Slack");
-
-            var box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 0);
-            box.pack_start (image, false, false, 0);
-            box.pack_start (label, false, false, 0);
-
-            menu_item.add (box);
-
-            list_box.insert (menu_item, 1);
-        }
-
-        {
-            var menu_item = new Gtk.MenuItem ();
-
-            var image = new Gtk.Image.from_gicon (Utilities.load_shared_icon ("org.telegram.web"), Gtk.IconSize.DND);
-            var label = new Gtk.Label ("Telegram");
-
-            var box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 0);
-            box.pack_start (image, false, false, 0);
-            box.pack_start (label, false, false, 0);
-
-            menu_item.add (box);
-
-            list_box.insert (menu_item, 2);
-        }
-
-        {
-            var menu_item = new Gtk.MenuItem ();
-
-            var image = new Gtk.Image.from_gicon (Utilities.load_shared_icon ("com.whatsapp.web"), Gtk.IconSize.DND);
-            var label = new Gtk.Label ("WhatsApp");
-
-            var box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 0);
-            box.pack_start (image, false, false, 0);
-            box.pack_start (label, false, false, 0);
-
-            menu_item.add (box);
-
-            list_box.insert (menu_item, 3);
+            list_box.insert (menu_item, i);
         }
 
         list_box.row_activated.connect ((row) => {
@@ -101,7 +57,6 @@ public class Views.MainView : Gtk.Paned {
         });
 
         var scroll = new Gtk.ScrolledWindow (null, null);
-        scroll.set_size_request (150, 150);
         scroll.hscrollbar_policy = Gtk.PolicyType.NEVER;
         scroll.expand = true;
         scroll.add (list_box);

--- a/src/Views/MainView.vala
+++ b/src/Views/MainView.vala
@@ -52,6 +52,8 @@ public class Views.MainView : Gtk.Paned {
                 if (stack.get_visible_child () != view) {
                     unread_notifications.label =
                         (messenger.unread_notifications > 0) ? "%u".printf (messenger.unread_notifications) : "";
+                } else if (messenger.unread_notifications == 0) {
+                    unread_notifications.label = "";
                 }
             });
 
@@ -67,6 +69,8 @@ public class Views.MainView : Gtk.Paned {
 
         list_box.row_activated.connect ((row) => {
             stack.set_visible_child_name ("%d".printf (row.get_index ()));
+            var view = stack.get_visible_child ();
+            (view as Widgets.MessengerView).model.unread_notifications = 0;
         });
 
         var scroll = new Gtk.ScrolledWindow (null, null);

--- a/src/Widgets/MessengerView.vala
+++ b/src/Widgets/MessengerView.vala
@@ -56,4 +56,10 @@ public class Widgets.MessengerView : WebKit.WebView {
 
         load_uri (this.messenger.url);
     }
+
+    public Models.Messenger model {
+        get {
+            return this.messenger;
+        }
+    }
 }

--- a/src/Widgets/MessengerView.vala
+++ b/src/Widgets/MessengerView.vala
@@ -19,13 +19,13 @@
 * Authored by: Marius Meisenzahl <mariusmeisenzahl@gmail.com>
 */
 
-public class Widgets.WebView : WebKit.WebView {
-    private string id;
+public class Widgets.MessengerView : WebKit.WebView {
+    private Models.Messenger messenger;
     private GLib.Icon icon;
 
-    public WebView (string url, string id) {
-        this.id = id;
-        this.icon = Utilities.load_shared_icon (this.id);
+    public MessengerView (Models.Messenger messenger) {
+        this.messenger = messenger;
+        this.icon = Utilities.load_shared_icon (this.messenger.id);
 
         var settings = this.get_settings();
         settings.enable_plugins = true;
@@ -35,7 +35,7 @@ public class Widgets.WebView : WebKit.WebView {
 
         web_context.initialize_notification_permissions.connect (() => {
             var allowed_origins = new List<WebKit.SecurityOrigin> ();
-            allowed_origins.append (new WebKit.SecurityOrigin.for_uri (url));
+            allowed_origins.append (new WebKit.SecurityOrigin.for_uri (this.messenger.url));
             var disallowed_origins = new List<WebKit.SecurityOrigin> ();
 
             web_context.init_notification_permissions (allowed_origins, disallowed_origins);
@@ -45,11 +45,11 @@ public class Widgets.WebView : WebKit.WebView {
             var native_notification = new GLib.Notification (notification.title);
             native_notification.set_body (notification.body);
             native_notification.set_icon (this.icon);
-            Application.instance.send_notification (this.id, native_notification);
+            Application.instance.send_notification (this.messenger.id, native_notification);
 
             return true;
         });
 
-        load_uri (url);
+        load_uri (this.messenger.url);
     }
 }

--- a/src/Widgets/MessengerView.vala
+++ b/src/Widgets/MessengerView.vala
@@ -47,6 +47,10 @@ public class Widgets.MessengerView : WebKit.WebView {
             native_notification.set_icon (this.icon);
             Application.instance.send_notification (this.messenger.id, native_notification);
 
+            this.messenger.unread_notifications += 1;
+
+            debug ("[%s] got notification".printf (this.messenger.id));
+
             return true;
         });
 

--- a/src/Widgets/MessengerView.vala
+++ b/src/Widgets/MessengerView.vala
@@ -27,7 +27,7 @@ public class Widgets.MessengerView : WebKit.WebView {
         this.messenger = messenger;
         this.icon = Utilities.load_shared_icon (this.messenger.id);
 
-        var settings = this.get_settings();
+        var settings = this.get_settings ();
         settings.enable_plugins = true;
         settings.enable_javascript = true;
         settings.enable_html5_database = true;

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,10 +1,11 @@
 sources = [
     'Config/Constants.vala',
     'Models/Messenger.vala',
+    'Services/Messengers.vala',
     'Services/Settings.vala',
     'Utilities/Icon.vala',
     'Views/MainView.vala',
-    'Widgets/WebView.vala',
+    'Widgets/MessengerView.vala',
     'MainWindow.vala'
 ]
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,5 +1,6 @@
 sources = [
     'Config/Constants.vala',
+    'Models/Messenger.vala',
     'Services/Settings.vala',
     'Utilities/Icon.vala',
     'Views/MainView.vala',


### PR DESCRIPTION
*Messages* should count the notifications and display the number in the GUI. In addition, the number of unread notifications should be displayed as a badge icon on the app icon.

![001](https://user-images.githubusercontent.com/10796736/74364041-0cb3d280-4dcc-11ea-8762-649ef7409b9c.png)

If possible, *Messages* should be opened and the corresponding messenger displayed when you click a native notification.